### PR TITLE
Add Qt chess project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build
+*.o
+*.pro.user
+*.qmake.stash
+CMakeFiles
+CMakeCache.txt
+cmake-build-*
+*.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(chessqt LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets Sql)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+qt_wrap_ui(UI_HEADERS
+    )
+
+add_executable(chessqt
+    main.cpp
+    login.cpp
+    mainwindow.cpp
+    chessboard.cpp
+    boardview.cpp
+    utils.cpp
+    resources.qrc
+)
+
+target_link_libraries(chessqt PRIVATE Qt6::Widgets Qt6::Sql)
+
+install(TARGETS chessqt RUNTIME DESTINATION bin)

--- a/src/boardview.cpp
+++ b/src/boardview.cpp
@@ -1,0 +1,30 @@
+#include "boardview.h"
+#include <QMouseEvent>
+#include <QGraphicsPixmapItem>
+#include "utils.h"
+
+BoardView::BoardView(QGraphicsScene *scene, ChessBoard *board, QWidget *parent)
+    : QGraphicsView(scene, parent), m_board(board)
+{
+}
+
+void BoardView::mousePressEvent(QMouseEvent *event)
+{
+    QPointF pos = mapToScene(event->pos());
+    int c = pos.x()/50;
+    int r = pos.y()/50;
+    if (c<0||c>=8||r<0||r>=8) return;
+    QString coord = posToStr(r,c);
+    if (m_selected.isEmpty()) {
+        ChessBoard::Piece p = m_board->pieceAt(r,c);
+        if (p!=ChessBoard::Empty)
+            m_selected = coord;
+    } else {
+        if (m_board->move(m_selected, coord)) {
+            m_selected.clear();
+            emit boardChanged();
+        } else {
+            m_selected.clear();
+        }
+    }
+}

--- a/src/boardview.h
+++ b/src/boardview.h
@@ -1,0 +1,24 @@
+#ifndef BOARDVIEW_H
+#define BOARDVIEW_H
+
+#include <QGraphicsView>
+#include "chessboard.h"
+
+class BoardView : public QGraphicsView
+{
+    Q_OBJECT
+public:
+    explicit BoardView(QGraphicsScene *scene, ChessBoard *board, QWidget *parent=nullptr);
+
+signals:
+    void boardChanged();
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override;
+
+private:
+    ChessBoard *m_board;
+    QString m_selected;
+};
+
+#endif // BOARDVIEW_H

--- a/src/chessboard.cpp
+++ b/src/chessboard.cpp
@@ -1,0 +1,41 @@
+#include "chessboard.h"
+
+ChessBoard::ChessBoard()
+{
+    reset();
+}
+
+void ChessBoard::reset()
+{
+    m_board.fill(Empty);
+    const Piece init[64] = {
+        WR, WN, WB, WQ, WK, WB, WN, WR,
+        WP, WP, WP, WP, WP, WP, WP, WP,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        BP, BP, BP, BP, BP, BP, BP, BP,
+        BR, BN, BB, BQ, BK, BB, BN, BR
+    };
+    for (int i=0;i<64;++i)
+        m_board[i]=init[i];
+    m_turn = White;
+}
+
+bool ChessBoard::move(const QString &from, const QString &to)
+{
+    // Simplified move: no legality checks
+    int fr = (7 - (from[1].digitValue()-1));
+    int fc = from[0].toLatin1()-'a';
+    int tr = (7 - (to[1].digitValue()-1));
+    int tc = to[0].toLatin1()-'a';
+    int fi = fr*8+fc;
+    int ti = tr*8+tc;
+    if (fi<0||fi>=64||ti<0||ti>=64)
+        return false;
+    m_board[ti] = m_board[fi];
+    m_board[fi] = Empty;
+    m_turn = (m_turn==White)?Black:White;
+    return true;
+}

--- a/src/chessboard.h
+++ b/src/chessboard.h
@@ -1,0 +1,25 @@
+#ifndef CHESSBOARD_H
+#define CHESSBOARD_H
+
+#include <array>
+#include <QString>
+
+class ChessBoard
+{
+public:
+    enum Color { White, Black };
+    enum Piece { Empty, WP, WR, WN, WB, WQ, WK, BP, BR, BN, BB, BQ, BK };
+
+    ChessBoard();
+    void reset();
+    bool move(const QString &from, const QString &to);
+    Piece pieceAt(int row, int col) const { return m_board[row*8+col]; }
+    Color currentColor() const { return m_turn; }
+
+private:
+    using Board = std::array<Piece, 64>;
+    Board m_board;
+    Color m_turn = White;
+};
+
+#endif // CHESSBOARD_H

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -1,0 +1,67 @@
+#include "login.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QMessageBox>
+
+Login::Login(QWidget *parent)
+    : QDialog(parent)
+{
+    setupDb();
+
+    setWindowTitle("Login");
+    auto *layout = new QVBoxLayout(this);
+    m_userEdit = new QLineEdit(this);
+    m_userEdit->setPlaceholderText("Username");
+    m_passEdit = new QLineEdit(this);
+    m_passEdit->setPlaceholderText("Password");
+    m_passEdit->setEchoMode(QLineEdit::Password);
+    m_loginBtn = new QPushButton("Login", this);
+    m_signBtn = new QPushButton("Sign up", this);
+    connect(m_loginBtn, &QPushButton::clicked, this, &Login::logIn);
+    connect(m_signBtn, &QPushButton::clicked, this, &Login::signIn);
+    layout->addWidget(m_userEdit);
+    layout->addWidget(m_passEdit);
+    auto *btnLayout = new QHBoxLayout;
+    btnLayout->addWidget(m_loginBtn);
+    btnLayout->addWidget(m_signBtn);
+    layout->addLayout(btnLayout);
+}
+
+void Login::setupDb()
+{
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName("players.db");
+    if (!db.open())
+        QMessageBox::critical(this, "DB", "Failed to open database");
+    QSqlQuery query(db);
+    query.exec("CREATE TABLE IF NOT EXISTS users(name TEXT PRIMARY KEY, pass TEXT)");
+}
+
+void Login::signIn()
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO users(name, pass) VALUES(?, ?)");
+    query.addBindValue(m_userEdit->text());
+    query.addBindValue(m_passEdit->text());
+    if (!query.exec()) {
+        QMessageBox::warning(this, "Sign in", "User exists");
+        return;
+    }
+    QMessageBox::information(this, "Sign in", "Account created");
+}
+
+void Login::logIn()
+{
+    QSqlQuery query;
+    query.prepare("SELECT pass FROM users WHERE name=?");
+    query.addBindValue(m_userEdit->text());
+    if (!query.exec() || !query.next() || query.value(0).toString() != m_passEdit->text()) {
+        QMessageBox::warning(this, "Login", "Invalid credentials");
+        return;
+    }
+    m_username = m_userEdit->text();
+    accept();
+}
+

--- a/src/login.h
+++ b/src/login.h
@@ -1,0 +1,30 @@
+#ifndef LOGIN_H
+#define LOGIN_H
+
+#include <QDialog>
+#include <QtSql>
+#include <QLineEdit>
+#include <QPushButton>
+#include "mainwindow.h"
+
+class Login : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit Login(QWidget *parent = nullptr);
+    QString username() const { return m_username; }
+
+private slots:
+    void signIn();
+    void logIn();
+
+private:
+    void setupDb();
+    QString m_username;
+    QLineEdit *m_userEdit;
+    QLineEdit *m_passEdit;
+    QPushButton *m_loginBtn;
+    QPushButton *m_signBtn;
+};
+
+#endif // LOGIN_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,16 @@
+#include <QApplication>
+#include "login.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    Login login;
+    if (!login.exec())
+        return 0;
+
+    MainWindow w(login.username());
+    w.show();
+
+    return app.exec();
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,0 +1,100 @@
+#include "mainwindow.h"
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QGraphicsRectItem>
+#include <QPixmap>
+#include "boardview.h"
+
+MainWindow::MainWindow(const QString &user, QWidget *parent)
+    : QMainWindow(parent), m_player(user)
+{
+    setWindowTitle("Chess - " + user);
+    auto *central = new QWidget(this);
+    auto *layout = new QVBoxLayout(central);
+    auto *playOffline = new QPushButton("Offline 2 Players", this);
+    auto *playAi = new QPushButton("Play vs AI", this);
+    layout->addWidget(playOffline);
+    layout->addWidget(playAi);
+    setCentralWidget(central);
+
+    connect(playOffline, &QPushButton::clicked, this, &MainWindow::chooseOffline);
+    connect(playAi, &QPushButton::clicked, this, &MainWindow::chooseVsAi);
+
+    m_scene = new QGraphicsScene(this);
+    m_view = new BoardView(m_scene, &m_board, this);
+    m_scene->setSceneRect(0,0,400,400);
+}
+
+void MainWindow::chooseOffline()
+{
+    m_mode = Offline;
+    startGame();
+}
+
+void MainWindow::chooseVsAi()
+{
+    m_mode = VsAi;
+    startGame();
+}
+
+void MainWindow::startGame()
+{
+    m_whiteTime = 600;
+    m_blackTime = 600;
+    m_board.reset();
+
+    m_scene->clear();
+    setCentralWidget(m_view);
+    redrawBoard();
+
+    m_timer.start(1000);
+    connect(&m_timer, &QTimer::timeout, this, &MainWindow::updateTimer);
+    connect(m_view, &BoardView::boardChanged, this, &MainWindow::redrawBoard);
+}
+
+void MainWindow::updateTimer()
+{
+    if (m_board.currentColor()==ChessBoard::White)
+        --m_whiteTime;
+    else
+        --m_blackTime;
+    if (m_whiteTime<=0 || m_blackTime<=0) {
+        QMessageBox::information(this, "Time", m_whiteTime<=0?"Black wins":"White wins");
+        m_timer.stop();
+        disconnect(&m_timer, &QTimer::timeout, this, &MainWindow::updateTimer);
+        return;
+    }
+}
+
+void MainWindow::redrawBoard()
+{
+    m_scene->clear();
+    for (int r=0;r<8;++r) {
+        for (int c=0;c<8;++c) {
+            m_scene->addRect(c*50,r*50,50,50,QPen(),(r+c)%2?QBrush(Qt::gray):QBrush(Qt::white));
+            ChessBoard::Piece p = m_board.pieceAt(r,c);
+            if (p!=ChessBoard::Empty) {
+                QString name;
+                switch (p) {
+                case ChessBoard::WP: name="pawn_w"; break;
+                case ChessBoard::WR: name="rook_w"; break;
+                case ChessBoard::WN: name="knight_w"; break;
+                case ChessBoard::WB: name="bishop_w"; break;
+                case ChessBoard::WQ: name="queen_w"; break;
+                case ChessBoard::WK: name="king_w"; break;
+                case ChessBoard::BP: name="pawn_b"; break;
+                case ChessBoard::BR: name="rook_b"; break;
+                case ChessBoard::BN: name="knight_b"; break;
+                case ChessBoard::BB: name="bishop_b"; break;
+                case ChessBoard::BQ: name="queen_b"; break;
+                case ChessBoard::BK: name="king_b"; break;
+                default: break;
+                }
+                QPixmap pix(":/images/"+name+".png");
+                m_scene->addPixmap(pix.scaled(50,50))->setPos(c*50,r*50);
+            }
+        }
+    }
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,0 +1,35 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include "boardview.h"
+#include <QGraphicsScene>
+#include <QTimer>
+#include "chessboard.h"
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(const QString &user, QWidget *parent = nullptr);
+
+private slots:
+    void startGame();
+    void chooseVsAi();
+    void chooseOffline();
+    void updateTimer();
+    void redrawBoard();
+
+private:
+    enum Mode { Off, Offline, VsAi };
+    Mode m_mode = Off;
+    QString m_player;
+    ChessBoard m_board;
+    BoardView *m_view;
+    QGraphicsScene *m_scene;
+    QTimer m_timer;
+    int m_whiteTime = 600; // 10 minutes
+    int m_blackTime = 600;
+};
+
+#endif // MAINWINDOW_H

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,0 +1,16 @@
+<RCC>
+    <qresource prefix="/images">
+        <file>../assets/rook_w.png</file>
+        <file>../assets/rook_b.png</file>
+        <file>../assets/knight_w.png</file>
+        <file>../assets/knight_b.png</file>
+        <file>../assets/bishop_w.png</file>
+        <file>../assets/bishop_b.png</file>
+        <file>../assets/queen_w.png</file>
+        <file>../assets/queen_b.png</file>
+        <file>../assets/king_w.png</file>
+        <file>../assets/king_b.png</file>
+        <file>../assets/pawn_w.png</file>
+        <file>../assets/pawn_b.png</file>
+    </qresource>
+</RCC>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,1 @@
+#include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,11 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <QString>
+
+inline QString posToStr(int row, int col)
+{
+    return QString("%1%2").arg(QChar('a'+col)).arg(8-row);
+}
+
+#endif // UTILS_H


### PR DESCRIPTION
## Summary
- add initial Qt6 project with CMake build
- implement Login dialog backed by SQLite
- create simple chess board and board view
- hook up basic time management
- include assets via Qt resource file

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/src/chessqt` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6850ea0e7c548320a184e4d8b9874c6e