### PR TITLE
Improve chess rules and AI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build
+*.o
+*.pro.user
+*.qmake.stash
+CMakeFiles
+CMakeCache.txt
+cmake-build-*
+*.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(chessqt LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets Sql Core)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+qt_wrap_ui(UI_HEADERS
+    )
+
+add_executable(chessqt
+    main.cpp
+    login.cpp
+    mainwindow.cpp
+    chessboard.cpp
+    boardview.cpp
+    utils.cpp
+    resources.qrc
+)
+
+target_link_libraries(chessqt PRIVATE Qt6::Widgets Qt6::Sql Qt6::Core)
+
+install(TARGETS chessqt RUNTIME DESTINATION bin)

--- a/src/boardview.cpp
+++ b/src/boardview.cpp
@@ -1,0 +1,44 @@
+#include "boardview.h"
+#include <QMouseEvent>
+#include <QGraphicsPixmapItem>
+#include "utils.h"
+
+BoardView::BoardView(QGraphicsScene *scene, ChessBoard *board, QWidget *parent)
+    : QGraphicsView(scene, parent), m_board(board)
+{
+}
+
+void BoardView::mousePressEvent(QMouseEvent *event)
+{
+    QPointF pos = mapToScene(event->pos());
+    int c = pos.x()/50;
+    int r = pos.y()/50;
+    if (c<0||c>=8||r<0||r>=8) return;
+    QString coord = posToStr(r,c);
+    if (m_selected.isEmpty()) {
+        ChessBoard::Piece p = m_board->pieceAt(r,c);
+        if (p!=ChessBoard::Empty && m_board->pieceColor(p)==m_board->currentColor()) {
+            m_selected = coord;
+            m_moves = m_board->legalMoves(coord);
+            emit highlightChanged(m_moves);
+        }
+    } else {
+        if (m_board->move(m_selected, coord)) {
+            m_selected.clear();
+            m_moves.clear();
+            emit boardChanged();
+            emit highlightChanged({});
+        } else {
+            m_selected.clear();
+            m_moves.clear();
+            emit highlightChanged({});
+        }
+    }
+}
+
+void BoardView::clearSelection()
+{
+    m_selected.clear();
+    m_moves.clear();
+    emit highlightChanged({});
+}

--- a/src/boardview.h
+++ b/src/boardview.h
@@ -1,0 +1,30 @@
+#ifndef BOARDVIEW_H
+#define BOARDVIEW_H
+
+#include <QGraphicsView>
+#include <QVector>
+#include "chessboard.h"
+
+class BoardView : public QGraphicsView
+{
+    Q_OBJECT
+public:
+    explicit BoardView(QGraphicsScene *scene, ChessBoard *board, QWidget *parent=nullptr);
+
+signals:
+    void boardChanged();
+    void highlightChanged(const QVector<QPoint> &moves);
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override;
+
+public:
+    void clearSelection();
+
+private:
+    ChessBoard *m_board;
+    QString m_selected;
+    QVector<QPoint> m_moves;
+};
+
+#endif // BOARDVIEW_H

--- a/src/chessboard.cpp
+++ b/src/chessboard.cpp
@@ -1,0 +1,111 @@
+#include "chessboard.h"
+
+ChessBoard::ChessBoard()
+{
+    reset();
+}
+
+void ChessBoard::reset()
+{
+    m_board.fill(Empty);
+    const Piece init[64] = {
+        BR, BN, BB, BQ, BK, BB, BN, BR,
+        BP, BP, BP, BP, BP, BP, BP, BP,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty,
+        WP, WP, WP, WP, WP, WP, WP, WP,
+        WR, WN, WB, WQ, WK, WB, WN, WR
+    };
+    for (int i=0;i<64;++i)
+        m_board[i]=init[i];
+    m_turn = White;
+    m_history.clear();
+}
+
+static void strToPos(const QString &s,int &r,int &c)
+{
+    c = s[0].toLatin1()-'a';
+    r = 7 - (s[1].digitValue()-1);
+}
+
+bool ChessBoard::move(const QString &from, const QString &to)
+{
+    QVector<QPoint> moves = legalMoves(from);
+    int tr,tc; strToPos(to,tr,tc);
+    bool legal=false;
+    for (const QPoint &p : moves) {
+        if (p.x()==tr && p.y()==tc) { legal=true; break; }
+    }
+    if (!legal)
+        return false;
+    int fr,fc; strToPos(from,fr,fc);
+    int fi = fr*8+fc;
+    int ti = tr*8+tc;
+    m_board[ti] = m_board[fi];
+    m_board[fi] = Empty;
+    m_turn = (m_turn==White)?Black:White;
+    m_history.append(from+to);
+    return true;
+}
+
+ChessBoard::Color ChessBoard::pieceColor(Piece p) const
+{
+    if (p>=WP && p<=WK) return White;
+    if (p>=BP && p<=BK) return Black;
+    return White;
+}
+
+QVector<QPoint> ChessBoard::legalMoves(const QString &from) const
+{
+    QVector<QPoint> res;
+    int r,c; strToPos(from,r,c);
+    Piece p = pieceAt(r,c);
+    if (p==Empty) return res;
+    Color col = pieceColor(p);
+    auto add=[&](int rr,int cc){
+        if (rr<0||rr>=8||cc<0||cc>=8) return false;
+        Piece t = pieceAt(rr,cc);
+        if (t==Empty) { res.append(QPoint(rr,cc)); return true; }
+        if (pieceColor(t)!=col) { res.append(QPoint(rr,cc)); return false; }
+        return false;
+    };
+
+    if (p==WP || p==BP) {
+        int dir = (p==WP)?-1:1;
+        int startRow = (p==WP)?6:1;
+        if (pieceAt(r+dir,c)==Empty) add(r+dir,c);
+        if (r==startRow && pieceAt(r+dir,c)==Empty && pieceAt(r+2*dir,c)==Empty) add(r+2*dir,c);
+        if (c>0) {
+            Piece t = pieceAt(r+dir,c-1);
+            if (t!=Empty && pieceColor(t)!=col) res.append(QPoint(r+dir,c-1));
+        }
+        if (c<7) {
+            Piece t = pieceAt(r+dir,c+1);
+            if (t!=Empty && pieceColor(t)!=col) res.append(QPoint(r+dir,c+1));
+        }
+        return res;
+    }
+
+    if (p==WN || p==BN) {
+        const int d[8][2]={{-2,-1},{-2,1},{-1,-2},{-1,2},{1,-2},{1,2},{2,-1},{2,1}};
+        for (auto &o:d) add(r+o[0],c+o[1]);
+        return res;
+    }
+    if (p==WB || p==BB || p==WQ || p==BQ) {
+        const int d[4][2]={{-1,-1},{-1,1},{1,-1},{1,1}};
+        for (auto &o:d){int rr=r+o[0],cc=c+o[1];while(add(rr,cc)){rr+=o[0];cc+=o[1];}}
+        if (p==WB || p==BB) return res; // bishops only
+    }
+    if (p==WR || p==BR || p==WQ || p==BQ) {
+        const int d[4][2]={{-1,0},{1,0},{0,-1},{0,1}};
+        for (auto &o:d){int rr=r+o[0],cc=c+o[1];while(add(rr,cc)){rr+=o[0];cc+=o[1];}}
+        if (p==WR || p==BR) return res; // rooks only
+    }
+    if (p==WK || p==BK) {
+        const int d[8][2]={{-1,-1},{-1,0},{-1,1},{0,-1},{0,1},{1,-1},{1,0},{1,1}};
+        for (auto &o:d) add(r+o[0],c+o[1]);
+    }
+    return res;
+}

--- a/src/chessboard.h
+++ b/src/chessboard.h
@@ -1,0 +1,31 @@
+#ifndef CHESSBOARD_H
+#define CHESSBOARD_H
+
+#include <array>
+#include <QString>
+#include <QVector>
+#include <QPoint>
+
+class ChessBoard
+{
+public:
+    enum Color { White, Black };
+    enum Piece { Empty, WP, WR, WN, WB, WQ, WK, BP, BR, BN, BB, BQ, BK };
+
+    ChessBoard();
+    void reset();
+    bool move(const QString &from, const QString &to);
+    QVector<QPoint> legalMoves(const QString &from) const;
+    Piece pieceAt(int row, int col) const { return m_board[row*8+col]; }
+    Color currentColor() const { return m_turn; }
+    Color pieceColor(Piece p) const;
+    QVector<QString> history() const { return m_history; }
+
+private:
+    using Board = std::array<Piece, 64>;
+    Board m_board;
+    Color m_turn = White;
+    QVector<QString> m_history;
+};
+
+#endif // CHESSBOARD_H

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -1,0 +1,67 @@
+#include "login.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QMessageBox>
+
+Login::Login(QWidget *parent)
+    : QDialog(parent)
+{
+    setupDb();
+
+    setWindowTitle("Login");
+    auto *layout = new QVBoxLayout(this);
+    m_userEdit = new QLineEdit(this);
+    m_userEdit->setPlaceholderText("Username");
+    m_passEdit = new QLineEdit(this);
+    m_passEdit->setPlaceholderText("Password");
+    m_passEdit->setEchoMode(QLineEdit::Password);
+    m_loginBtn = new QPushButton("Login", this);
+    m_signBtn = new QPushButton("Sign up", this);
+    connect(m_loginBtn, &QPushButton::clicked, this, &Login::logIn);
+    connect(m_signBtn, &QPushButton::clicked, this, &Login::signIn);
+    layout->addWidget(m_userEdit);
+    layout->addWidget(m_passEdit);
+    auto *btnLayout = new QHBoxLayout;
+    btnLayout->addWidget(m_loginBtn);
+    btnLayout->addWidget(m_signBtn);
+    layout->addLayout(btnLayout);
+}
+
+void Login::setupDb()
+{
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName("players.db");
+    if (!db.open())
+        QMessageBox::critical(this, "DB", "Failed to open database");
+    QSqlQuery query(db);
+    query.exec("CREATE TABLE IF NOT EXISTS users(name TEXT PRIMARY KEY, pass TEXT)");
+}
+
+void Login::signIn()
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO users(name, pass) VALUES(?, ?)");
+    query.addBindValue(m_userEdit->text());
+    query.addBindValue(m_passEdit->text());
+    if (!query.exec()) {
+        QMessageBox::warning(this, "Sign in", "User exists");
+        return;
+    }
+    QMessageBox::information(this, "Sign in", "Account created");
+}
+
+void Login::logIn()
+{
+    QSqlQuery query;
+    query.prepare("SELECT pass FROM users WHERE name=?");
+    query.addBindValue(m_userEdit->text());
+    if (!query.exec() || !query.next() || query.value(0).toString() != m_passEdit->text()) {
+        QMessageBox::warning(this, "Login", "Invalid credentials");
+        return;
+    }
+    m_username = m_userEdit->text();
+    accept();
+}
+

--- a/src/login.h
+++ b/src/login.h
@@ -1,0 +1,30 @@
+#ifndef LOGIN_H
+#define LOGIN_H
+
+#include <QDialog>
+#include <QtSql>
+#include <QLineEdit>
+#include <QPushButton>
+#include "mainwindow.h"
+
+class Login : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit Login(QWidget *parent = nullptr);
+    QString username() const { return m_username; }
+
+private slots:
+    void signIn();
+    void logIn();
+
+private:
+    void setupDb();
+    QString m_username;
+    QLineEdit *m_userEdit;
+    QLineEdit *m_passEdit;
+    QPushButton *m_loginBtn;
+    QPushButton *m_signBtn;
+};
+
+#endif // LOGIN_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,16 @@
+#include <QApplication>
+#include "login.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    Login login;
+    if (!login.exec())
+        return 0;
+
+    MainWindow w(login.username());
+    w.show();
+
+    return app.exec();
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,0 +1,186 @@
+#include "mainwindow.h"
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QGraphicsRectItem>
+#include <QPixmap>
+#include <QRandomGenerator>
+#include "boardview.h"
+
+MainWindow::MainWindow(const QString &user, QWidget *parent)
+    : QMainWindow(parent), m_player(user)
+{
+    setWindowTitle("Chess - " + user);
+    auto *central = new QWidget(this);
+    auto *layout = new QVBoxLayout(central);
+    auto *playOffline = new QPushButton("Offline 2 Players", this);
+    auto *playAi = new QPushButton("Play vs AI", this);
+    layout->addWidget(playOffline);
+    layout->addWidget(playAi);
+    setCentralWidget(central);
+
+    connect(playOffline, &QPushButton::clicked, this, &MainWindow::chooseOffline);
+    connect(playAi, &QPushButton::clicked, this, &MainWindow::chooseVsAi);
+
+    m_scene = new QGraphicsScene(this);
+    m_view = new BoardView(m_scene, &m_board, this);
+    m_scene->setSceneRect(0,0,400,400);
+}
+
+void MainWindow::chooseOffline()
+{
+    m_mode = Offline;
+    startGame();
+}
+
+void MainWindow::chooseVsAi()
+{
+    QStringList opts{"White","Black","Random"};
+    bool ok=false;
+    QString choice = QInputDialog::getItem(this,"Play vs AI","Select side",opts,0,false,&ok);
+    if(!ok) return;
+    if(choice=="Random")
+        m_playerColor = (QRandomGenerator::global()->bounded(2)==0)?ChessBoard::White:ChessBoard::Black;
+    else
+        m_playerColor = (choice=="White")?ChessBoard::White:ChessBoard::Black;
+    m_mode = VsAi;
+    startGame();
+    if(m_playerColor==ChessBoard::Black)
+        requestAiMove();
+}
+
+void MainWindow::startGame()
+{
+    m_whiteTime = 600;
+    m_blackTime = 600;
+    m_board.reset();
+    m_highlight.clear();
+
+    m_scene->clear();
+    setCentralWidget(m_view);
+    redrawBoard();
+
+    m_timer.start(1000);
+    connect(&m_timer, &QTimer::timeout, this, &MainWindow::updateTimer);
+    connect(m_view, &BoardView::boardChanged, this, &MainWindow::onBoardChange);
+    connect(m_view, &BoardView::highlightChanged, this, &MainWindow::setHighlight);
+
+    if(m_mode==VsAi){
+        if(!m_engine){
+            m_engine = new QProcess(this);
+            m_engine->start("stockfish");
+            m_engine->write("uci\n");
+            m_engine->write("isready\n");
+            m_engine->waitForReadyRead(3000);
+            m_engine->readAll();
+            connect(m_engine,&QProcess::readyRead,this,&MainWindow::readAiMove);
+        }
+    }
+}
+
+void MainWindow::updateTimer()
+{
+    if (m_board.currentColor()==ChessBoard::White)
+        --m_whiteTime;
+    else
+        --m_blackTime;
+    if (m_whiteTime<=0 || m_blackTime<=0) {
+        QMessageBox::information(this, "Time", m_whiteTime<=0?"Black wins":"White wins");
+        m_timer.stop();
+        disconnect(&m_timer, &QTimer::timeout, this, &MainWindow::updateTimer);
+        return;
+    }
+}
+
+void MainWindow::redrawBoard()
+{
+    m_scene->clear();
+    for (int r=0;r<8;++r) {
+        for (int c=0;c<8;++c) {
+            QBrush brush = ((r+c)%2)?QBrush(Qt::gray):QBrush(Qt::white);
+            for(const QPoint &p : m_highlight){ if(p.x()==r && p.y()==c){ brush = QBrush(Qt::yellow); break; } }
+            m_scene->addRect(c*50,r*50,50,50,QPen(),brush);
+            ChessBoard::Piece p = m_board.pieceAt(r,c);
+            if (p!=ChessBoard::Empty) {
+                QString name;
+                switch (p) {
+                case ChessBoard::WP: name="pawn_w"; break;
+                case ChessBoard::WR: name="rook_w"; break;
+                case ChessBoard::WN: name="knight_w"; break;
+                case ChessBoard::WB: name="bishop_w"; break;
+                case ChessBoard::WQ: name="queen_w"; break;
+                case ChessBoard::WK: name="king_w"; break;
+                case ChessBoard::BP: name="pawn_b"; break;
+                case ChessBoard::BR: name="rook_b"; break;
+                case ChessBoard::BN: name="knight_b"; break;
+                case ChessBoard::BB: name="bishop_b"; break;
+                case ChessBoard::BQ: name="queen_b"; break;
+                case ChessBoard::BK: name="king_b"; break;
+                default: break;
+                }
+                QPixmap pix(":/images/"+name+".png");
+                m_scene->addPixmap(pix.scaled(50,50))->setPos(c*50,r*50);
+            }
+        }
+    }
+}
+
+void MainWindow::onBoardChange()
+{
+    redrawBoard();
+    checkGameOver();
+    if(m_mode==VsAi && m_board.currentColor()!=m_playerColor)
+        requestAiMove();
+}
+
+void MainWindow::setHighlight(const QVector<QPoint> &moves)
+{
+    m_highlight = moves;
+    redrawBoard();
+}
+
+void MainWindow::requestAiMove()
+{
+    if(!m_engine) return;
+    QString cmd = "position startpos";
+    auto hist = m_board.history();
+    if(!hist.isEmpty())
+        cmd += " moves " + hist.join(' ');
+    m_engine->write(cmd.toUtf8()+"\n");
+    m_engine->write("go movetime 1000\n");
+}
+
+void MainWindow::readAiMove()
+{
+    while(m_engine->canReadLine()){
+        QByteArray line = m_engine->readLine();
+        if(line.startsWith("bestmove")){
+            QList<QByteArray> parts = line.split(' ');
+            if(parts.size()>=2){
+                QString mv = parts[1];
+                QString from = mv.mid(0,2);
+                QString to = mv.mid(2,2);
+                m_board.move(from,to);
+                m_view->clearSelection();
+                redrawBoard();
+            }
+        }
+    }
+}
+
+void MainWindow::checkGameOver()
+{
+    bool w=false,b=false;
+    for(int r=0;r<8;++r)
+        for(int c=0;c<8;++c){
+            ChessBoard::Piece p=m_board.pieceAt(r,c);
+            if(p==ChessBoard::WK) w=true;
+            if(p==ChessBoard::BK) b=true;
+        }
+    if(!w||!b){
+        QMessageBox::information(this,"Game Over",!w?"Black wins":"White wins");
+        m_timer.stop();
+        setCentralWidget(nullptr);
+    }
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,0 +1,46 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include "boardview.h"
+#include <QGraphicsScene>
+#include <QTimer>
+#include <QProcess>
+#include <QVector>
+#include <QPoint>
+#include "chessboard.h"
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(const QString &user, QWidget *parent = nullptr);
+
+private slots:
+    void startGame();
+    void chooseVsAi();
+    void chooseOffline();
+    void updateTimer();
+    void redrawBoard();
+    void setHighlight(const QVector<QPoint> &moves);
+    void readAiMove();
+    void requestAiMove();
+    void onBoardChange();
+    void checkGameOver();
+
+private:
+    enum Mode { Off, Offline, VsAi };
+    Mode m_mode = Off;
+    QString m_player;
+    ChessBoard m_board;
+    BoardView *m_view;
+    QGraphicsScene *m_scene;
+    QTimer m_timer;
+    QVector<QPoint> m_highlight;
+    QProcess *m_engine = nullptr;
+    ChessBoard::Color m_playerColor = ChessBoard::White;
+    int m_whiteTime = 600; // 10 minutes
+    int m_blackTime = 600;
+};
+
+#endif // MAINWINDOW_H

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,0 +1,16 @@
+<RCC>
+    <qresource prefix="/images">
+        <file>../assets/rook_w.png</file>
+        <file>../assets/rook_b.png</file>
+        <file>../assets/knight_w.png</file>
+        <file>../assets/knight_b.png</file>
+        <file>../assets/bishop_w.png</file>
+        <file>../assets/bishop_b.png</file>
+        <file>../assets/queen_w.png</file>
+        <file>../assets/queen_b.png</file>
+        <file>../assets/king_w.png</file>
+        <file>../assets/king_b.png</file>
+        <file>../assets/pawn_w.png</file>
+        <file>../assets/pawn_b.png</file>
+    </qresource>
+</RCC>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,1 @@
+#include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,11 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <QString>
+
+inline QString posToStr(int row, int col)
+{
+    return QString("%1%2").arg(QChar('a'+col)).arg(8-row);
+}
+
+#endif // UTILS_H


### PR DESCRIPTION
## Summary
- fix initial board so white pieces start at the bottom
- compute basic legal moves and maintain move history
- highlight legal moves on board selection
- stub Stockfish AI integration with QProcess
- show basic game-over detection

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/src/chessqt` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6850ea0e7c548320a184e4d8b9874c6e