### PR TITLE
Implement check detection and special moves

### DIFF
--- a/src/chessboard.cpp
+++ b/src/chessboard.cpp
@@ -22,6 +22,13 @@ void ChessBoard::reset()
         m_board[i]=init[i];
     m_turn = White;
     m_history.clear();
+    m_whiteKingMoved = false;
+    m_blackKingMoved = false;
+    m_whiteLeftRookMoved = false;
+    m_whiteRightRookMoved = false;
+    m_blackLeftRookMoved = false;
+    m_blackRightRookMoved = false;
+    m_enPassant = QPoint(-1,-1);
 }
 
 static void strToPos(const QString &s,int &r,int &c)
@@ -43,8 +50,56 @@ bool ChessBoard::move(const QString &from, const QString &to)
     int fr,fc; strToPos(from,fr,fc);
     int fi = fr*8+fc;
     int ti = tr*8+tc;
-    m_board[ti] = m_board[fi];
+
+    Piece moving = m_board[fi];
+
+    // handle castling
+    if (moving==WK && abs(tc-fc)==2) {
+        // king side or queen side
+        if (tc>fc) { // king side
+            m_board[tr*8+5] = m_board[tr*8+7];
+            m_board[tr*8+7] = Empty;
+        } else {
+            m_board[tr*8+3] = m_board[tr*8+0];
+            m_board[tr*8+0] = Empty;
+        }
+    }
+    if (moving==BK && abs(tc-fc)==2) {
+        if (tc>fc) {
+            m_board[tr*8+5] = m_board[tr*8+7];
+            m_board[tr*8+7] = Empty;
+        } else {
+            m_board[tr*8+3] = m_board[tr*8+0];
+            m_board[tr*8+0] = Empty;
+        }
+    }
+
+    // handle en passant capture
+    if ((moving==WP || moving==BP) && QPoint(tr,tc)==m_enPassant) {
+        int capR = (moving==WP)?tr+1:tr-1;
+        m_board[capR*8+tc] = Empty;
+    }
+
+    m_board[ti] = moving;
     m_board[fi] = Empty;
+
+    // pawn promotion to queen
+    if (moving==WP && tr==0) m_board[ti] = WQ;
+    if (moving==BP && tr==7) m_board[ti] = BQ;
+
+    // update castling rights
+    if (moving==WK) m_whiteKingMoved=true;
+    if (moving==BK) m_blackKingMoved=true;
+    if (fi==7*8+0) m_whiteLeftRookMoved=true;
+    if (fi==7*8+7) m_whiteRightRookMoved=true;
+    if (fi==0*8+0) m_blackLeftRookMoved=true;
+    if (fi==0*8+7) m_blackRightRookMoved=true;
+
+    // set en passant target
+    m_enPassant = QPoint(-1,-1);
+    if ((moving==WP && fr==6 && tr==4) || (moving==BP && fr==1 && tr==3))
+        m_enPassant = QPoint((moving==WP)?5:2,tc);
+
     m_turn = (m_turn==White)?Black:White;
     m_history.append(from+to);
     return true;
@@ -75,37 +130,113 @@ QVector<QPoint> ChessBoard::legalMoves(const QString &from) const
     if (p==WP || p==BP) {
         int dir = (p==WP)?-1:1;
         int startRow = (p==WP)?6:1;
-        if (pieceAt(r+dir,c)==Empty) add(r+dir,c);
-        if (r==startRow && pieceAt(r+dir,c)==Empty && pieceAt(r+2*dir,c)==Empty) add(r+2*dir,c);
+        if (pieceAt(r+dir,c)==Empty)
+            add(r+dir,c);
+        if (r==startRow && pieceAt(r+dir,c)==Empty && pieceAt(r+2*dir,c)==Empty)
+            add(r+2*dir,c);
         if (c>0) {
             Piece t = pieceAt(r+dir,c-1);
-            if (t!=Empty && pieceColor(t)!=col) res.append(QPoint(r+dir,c-1));
+            if (t!=Empty && pieceColor(t)!=col)
+                res.append(QPoint(r+dir,c-1));
         }
         if (c<7) {
             Piece t = pieceAt(r+dir,c+1);
-            if (t!=Empty && pieceColor(t)!=col) res.append(QPoint(r+dir,c+1));
+            if (t!=Empty && pieceColor(t)!=col)
+                res.append(QPoint(r+dir,c+1));
         }
-        return res;
+        if (m_enPassant.x()!=-1 && r==m_enPassant.x()+((p==WP)?1:-1) && abs(c-m_enPassant.y())==1)
+            res.append(m_enPassant);
     }
 
     if (p==WN || p==BN) {
         const int d[8][2]={{-2,-1},{-2,1},{-1,-2},{-1,2},{1,-2},{1,2},{2,-1},{2,1}};
         for (auto &o:d) add(r+o[0],c+o[1]);
-        return res;
     }
     if (p==WB || p==BB || p==WQ || p==BQ) {
         const int d[4][2]={{-1,-1},{-1,1},{1,-1},{1,1}};
         for (auto &o:d){int rr=r+o[0],cc=c+o[1];while(add(rr,cc)){rr+=o[0];cc+=o[1];}}
-        if (p==WB || p==BB) return res; // bishops only
+        if (p==WB || p==BB) {}
     }
     if (p==WR || p==BR || p==WQ || p==BQ) {
         const int d[4][2]={{-1,0},{1,0},{0,-1},{0,1}};
         for (auto &o:d){int rr=r+o[0],cc=c+o[1];while(add(rr,cc)){rr+=o[0];cc+=o[1];}}
-        if (p==WR || p==BR) return res; // rooks only
+        if (p==WR || p==BR) {}
     }
     if (p==WK || p==BK) {
         const int d[8][2]={{-1,-1},{-1,0},{-1,1},{0,-1},{0,1},{1,-1},{1,0},{1,1}};
         for (auto &o:d) add(r+o[0],c+o[1]);
+        // castling
+        if(col==White && !m_whiteKingMoved){
+            if(!m_whiteRightRookMoved && pieceAt(7,5)==Empty && pieceAt(7,6)==Empty && !isSquareAttacked(7,4,Black) && !isSquareAttacked(7,5,Black) && !isSquareAttacked(7,6,Black))
+                res.append(QPoint(7,6));
+            if(!m_whiteLeftRookMoved && pieceAt(7,3)==Empty && pieceAt(7,2)==Empty && pieceAt(7,1)==Empty && !isSquareAttacked(7,4,Black) && !isSquareAttacked(7,3,Black) && !isSquareAttacked(7,2,Black))
+                res.append(QPoint(7,2));
+        }
+        if(col==Black && !m_blackKingMoved){
+            if(!m_blackRightRookMoved && pieceAt(0,5)==Empty && pieceAt(0,6)==Empty && !isSquareAttacked(0,4,White) && !isSquareAttacked(0,5,White) && !isSquareAttacked(0,6,White))
+                res.append(QPoint(0,6));
+            if(!m_blackLeftRookMoved && pieceAt(0,3)==Empty && pieceAt(0,2)==Empty && pieceAt(0,1)==Empty && !isSquareAttacked(0,4,White) && !isSquareAttacked(0,3,White) && !isSquareAttacked(0,2,White))
+                res.append(QPoint(0,2));
+        }
     }
-    return res;
+
+    QVector<QPoint> final;
+    for(const QPoint &m : res){
+        ChessBoard tmp = *this;
+        int fi=r*8+c;
+        int ti=m.x()*8+m.y();
+        tmp.m_board[ti]=tmp.m_board[fi];
+        tmp.m_board[fi]=Empty;
+        if(!tmp.isInCheck(col))
+            final.append(m);
+    }
+    return final;
+}
+
+bool ChessBoard::isSquareAttacked(int r,int c,Color by) const
+{
+    int dir = (by==White)?-1:1;
+    // pawn attacks
+    if(r-dir>=0 && r-dir<8){
+        if(c>0 && pieceAt(r-dir,c-1)==(by==White?WP:BP)) return true;
+        if(c<7 && pieceAt(r-dir,c+1)==(by==White?WP:BP)) return true;
+    }
+    // knight attacks
+    const int nd[8][2]={{-2,-1},{-2,1},{-1,-2},{-1,2},{1,-2},{1,2},{2,-1},{2,1}};
+    for(auto &o:nd){int rr=r+o[0],cc=c+o[1];if(rr>=0&&rr<8&&cc>=0&&cc<8){Piece t=pieceAt(rr,cc);if(t==(by==White?WN:BN)) return true;}}
+    // bishop/queen attacks
+    const int bd[4][2]={{-1,-1},{-1,1},{1,-1},{1,1}};
+    for(auto&o:bd){int rr=r+o[0],cc=c+o[1];while(rr>=0&&rr<8&&cc>=0&&cc<8){Piece t=pieceAt(rr,cc);if(t!=Empty){if(pieceColor(t)==by&&(t==BB||t==BQ||t==WB||t==WQ)) return true; break;}rr+=o[0];cc+=o[1];}}
+    // rook/queen attacks
+    const int rd[4][2]={{-1,0},{1,0},{0,-1},{0,1}};
+    for(auto&o:rd){int rr=r+o[0],cc=c+o[1];while(rr>=0&&rr<8&&cc>=0&&cc<8){Piece t=pieceAt(rr,cc);if(t!=Empty){if(pieceColor(t)==by&&(t==BR||t==BQ||t==WR||t==WQ)) return true; break;}rr+=o[0];cc+=o[1];}}
+    // king attacks
+    const int kd[8][2]={{-1,-1},{-1,0},{-1,1},{0,-1},{0,1},{1,-1},{1,0},{1,1}};
+    for(auto&o:kd){int rr=r+o[0],cc=c+o[1];if(rr>=0&&rr<8&&cc>=0&&cc<8){Piece t=pieceAt(rr,cc);if(t==(by==White?WK:BK)) return true;}}
+    return false;
+}
+
+bool ChessBoard::isInCheck(Color c) const
+{
+    for(int r=0;r<8;++r)
+        for(int col=0;col<8;++col){
+            Piece p = pieceAt(r,col);
+            if(p==(c==White?WK:BK))
+                return isSquareAttacked(r,col,c==White?Black:White);
+        }
+    return false;
+}
+
+bool ChessBoard::hasMoves(Color c) const
+{
+    for(int r=0;r<8;++r)
+        for(int col=0;col<8;++col){
+            Piece p=pieceAt(r,col);
+            if(p!=Empty && pieceColor(p)==c){
+                QString pos = QString("%1%2").arg(QChar('a'+col)).arg(8-r);
+                if(!legalMoves(pos).isEmpty())
+                    return true;
+            }
+        }
+    return false;
 }

--- a/src/chessboard.h
+++ b/src/chessboard.h
@@ -16,6 +16,8 @@ public:
     void reset();
     bool move(const QString &from, const QString &to);
     QVector<QPoint> legalMoves(const QString &from) const;
+    bool isInCheck(Color c) const;
+    bool hasMoves(Color c) const;
     Piece pieceAt(int row, int col) const { return m_board[row*8+col]; }
     Color currentColor() const { return m_turn; }
     Color pieceColor(Piece p) const;
@@ -26,6 +28,15 @@ private:
     Board m_board;
     Color m_turn = White;
     QVector<QString> m_history;
+    bool m_whiteKingMoved = false;
+    bool m_blackKingMoved = false;
+    bool m_whiteLeftRookMoved = false;
+    bool m_whiteRightRookMoved = false;
+    bool m_blackLeftRookMoved = false;
+    bool m_blackRightRookMoved = false;
+    QPoint m_enPassant{-1,-1};
+
+    bool isSquareAttacked(int r,int c,Color by) const;
 };
 
 #endif // CHESSBOARD_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -173,15 +173,14 @@ void MainWindow::readAiMove()
 
 void MainWindow::checkGameOver()
 {
-    bool w=false,b=false;
-    for(int r=0;r<8;++r)
-        for(int c=0;c<8;++c){
-            ChessBoard::Piece p=m_board.pieceAt(r,c);
-            if(p==ChessBoard::WK) w=true;
-            if(p==ChessBoard::BK) b=true;
-        }
-    if(!w||!b){
-        QMessageBox::information(this,"Game Over",!w?"Black wins":"White wins");
+    ChessBoard::Color cur = m_board.currentColor();
+    if(!m_board.hasMoves(cur)){
+        QString msg;
+        if(m_board.isInCheck(cur))
+            msg = (cur==ChessBoard::White)?"Black wins":"White wins";
+        else
+            msg = "Stalemate";
+        QMessageBox::information(this,"Game Over",msg);
         m_timer.stop();
         setCentralWidget(nullptr);
     }


### PR DESCRIPTION
## Summary
- add more game state tracking in `ChessBoard`
- implement move rules for castling, en passant and promotion
- detect check and checkmate/stalemate
- update `MainWindow` to use new end-game logic

## Testing
- `cmake ..`
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_685131a223f48320a5064de51b1de897