### PR TITLE
Update game end flow

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -30,6 +30,10 @@ private slots:
     void checkGameOver();
 
 private:
+    void showMenu();
+    void endGame();
+
+private:
     enum Mode { Off, Offline, VsAi };
     Mode m_mode = Off;
     QString m_player;


### PR DESCRIPTION
## Summary
- add helper methods to show the main menu and clean up the game
- call these helpers so that the main window returns to the mode selection screen after a match ends

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68513dbbc9f4832093e62b6647bea256