### PR TITLE
Implement AI game over and timer display

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -9,6 +9,7 @@
 #include <QNetworkReply>
 #include <QVector>
 #include <QPoint>
+#include <QLabel>
 #include "chessboard.h"
 
 class MainWindow : public QMainWindow
@@ -32,6 +33,7 @@ private slots:
 private:
     void showMenu();
     void endGame();
+    void updateTimerDisplay();
 
 private:
     enum Mode { Off, Offline, VsAi };
@@ -47,6 +49,8 @@ private:
     ChessBoard::Color m_playerColor = ChessBoard::White;
     int m_whiteTime = 600; // 10 minutes
     int m_blackTime = 600;
+    QLabel *m_whiteLabel = nullptr;
+    QLabel *m_blackLabel = nullptr;
 
 public:
     bool backToLoginRequested() const { return m_backToLogin; }


### PR DESCRIPTION
## Summary
- show timers with white/black remaining time
- hide timers when not playing
- call game-over check after AI moves
- display timers in UI

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68514012bd3c8320863bd2f9da02864d