### PR TITLE
Implement AI game over and timer display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Chess Qt
+
+Simple chess game implemented in Qt.
+
+## Build
+
+Requires Qt 6 and CMake.
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Run `./chessqt` inside `build` directory.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,10 +1,12 @@
 #include "mainwindow.h"
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QPushButton>
 #include <QMessageBox>
 #include <QInputDialog>
 #include <QGraphicsRectItem>
 #include <QPixmap>
+#include <QLabel>
 #include <QRandomGenerator>
 #include <QNetworkRequest>
 #include <QUrlQuery>
@@ -19,6 +21,11 @@ MainWindow::MainWindow(const QString &user, QWidget *parent)
     m_scene = new QGraphicsScene(this);
     m_view = new BoardView(m_scene, &m_board, this);
     m_scene->setSceneRect(0,0,400,400);
+
+    m_whiteLabel = new QLabel(this);
+    m_blackLabel = new QLabel(this);
+    m_whiteLabel->setVisible(false);
+    m_blackLabel->setVisible(false);
 
     showMenu();
 }
@@ -53,8 +60,22 @@ void MainWindow::startGame()
     m_highlight.clear();
 
     m_scene->clear();
-    setCentralWidget(m_view);
+
+    auto *central = new QWidget(this);
+    auto *layout = new QVBoxLayout(central);
+    layout->setContentsMargins(0,0,0,0);
+    layout->addWidget(m_view);
+    auto *timerLayout = new QHBoxLayout();
+    timerLayout->addWidget(m_whiteLabel);
+    timerLayout->addStretch();
+    timerLayout->addWidget(m_blackLabel);
+    layout->addLayout(timerLayout);
+    setCentralWidget(central);
     redrawBoard();
+
+    m_whiteLabel->setVisible(true);
+    m_blackLabel->setVisible(true);
+    updateTimerDisplay();
 
     m_timer.start(1000);
     connect(&m_timer, &QTimer::timeout, this, &MainWindow::updateTimer);
@@ -74,6 +95,7 @@ void MainWindow::updateTimer()
         --m_whiteTime;
     else
         --m_blackTime;
+    updateTimerDisplay();
     if (m_whiteTime<=0 || m_blackTime<=0) {
         QMessageBox::information(this, "Time", m_whiteTime<=0?"Black wins":"White wins");
         endGame();
@@ -158,6 +180,7 @@ void MainWindow::handleAiReply(QNetworkReply *reply)
         m_board.move(from,to);
         m_view->clearSelection();
         redrawBoard();
+        checkGameOver();
     }
 }
 
@@ -177,6 +200,8 @@ void MainWindow::checkGameOver()
 
 void MainWindow::showMenu()
 {
+    m_whiteLabel->setVisible(false);
+    m_blackLabel->setVisible(false);
     auto *central = new QWidget(this);
     auto *layout = new QVBoxLayout(central);
     auto *playOffline = new QPushButton("Offline 2 Players", this);
@@ -197,5 +222,14 @@ void MainWindow::endGame()
     disconnect(m_view, &BoardView::highlightChanged, this, &MainWindow::setHighlight);
     m_highlight.clear();
     m_mode = Off;
+    m_whiteLabel->setVisible(false);
+    m_blackLabel->setVisible(false);
     showMenu();
+}
+
+void MainWindow::updateTimerDisplay()
+{
+    auto format=[&](int t){ return QString("%1:%2").arg(t/60,2,10,QChar('0')).arg(t%60,2,10,QChar('0')); };
+    m_whiteLabel->setText("White: " + format(m_whiteTime));
+    m_blackLabel->setText("Black: " + format(m_blackTime));
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -9,6 +9,7 @@
 #include <QNetworkReply>
 #include <QVector>
 #include <QPoint>
+#include <QLabel>
 #include "chessboard.h"
 
 class MainWindow : public QMainWindow
@@ -32,6 +33,7 @@ private slots:
 private:
     void showMenu();
     void endGame();
+    void updateTimerDisplay();
 
 private:
     enum Mode { Off, Offline, VsAi };
@@ -47,6 +49,8 @@ private:
     ChessBoard::Color m_playerColor = ChessBoard::White;
     int m_whiteTime = 600; // 10 minutes
     int m_blackTime = 600;
+    QLabel *m_whiteLabel = nullptr;
+    QLabel *m_blackLabel = nullptr;
 
 public:
     bool backToLoginRequested() const { return m_backToLogin; }


### PR DESCRIPTION
## Summary
- show timers with white/black remaining time
- hide timers when not playing
- call game-over check after AI moves
- display timers in UI
- remove QStatusBar usage to avoid errors
- add README with build instructions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure` *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68514012bd3c8320863bd2f9da02864d