### PR TITLE
Fix crash when starting a new game

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,6 +61,8 @@ void MainWindow::startGame()
 
     m_scene->clear();
 
+    if(QWidget *old = centralWidget())
+        old->deleteLater();
     auto *central = new QWidget(this);
     auto *layout = new QVBoxLayout(central);
     layout->setContentsMargins(0,0,0,0);
@@ -201,7 +203,11 @@ void MainWindow::checkGameOver()
 
 void MainWindow::showMenu()
 {
+    if(QWidget *old = centralWidget())
+        old->deleteLater();
 
+    if(m_net)
+        m_net->disconnect(this);
     // keep widgets alive when replacing the central widget
     m_view->setParent(this);
     m_whiteLabel->setParent(this);


### PR DESCRIPTION
## Summary
- ensure timer labels aren't deleted when returning to the menu

## Testing
- `cmake --build build`
- `ctest --output-on-failure` *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68514012bd3c8320863bd2f9da02864d