### PR TITLE
Compile Stockfish with project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CMakeFiles
 CMakeCache.txt
 cmake-build-*
 *.db
+stockfish/engine/stockfish

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Widgets Sql Core)
 
+# Build the bundled Stockfish engine. We cannot rely on ${CMAKE_MAKE_PROGRAM}
+# here, because the main project might use Ninja while the engine ships with a
+# traditional Makefile. Call make explicitly instead.
+add_custom_target(build_stockfish ALL
+    COMMAND make build
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/src
+    COMMENT "Building Stockfish engine"
+)
+
+add_custom_command(TARGET build_stockfish POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/src/stockfish
+            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/stockfish
+)
+
 add_subdirectory(src)
+
+add_dependencies(chessqt build_stockfish)

--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ cmake -S . -B build
 cmake --build build
 ```
 
-Run `./chessqt` inside `build` directory.
+The build will also compile the bundled **Stockfish** engine. The resulting
+engine binary is copied to `stockfish/engine/stockfish` so that playing
+against the AI works out of the box.
+
+Run `./chessqt` inside the `build` directory to start the application.


### PR DESCRIPTION
## Summary
- build Stockfish engine as part of the project
- copy the resulting binary so the AI mode can launch the engine
- ignore generated engine binary
- mention engine build in README
- fix build for Ninja by calling make directly

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_685192f528d48320ba4ea3078f017669