### PR TITLE
Fix building stockfish on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,19 @@ find_package(Qt6 REQUIRED COMPONENTS Widgets Sql Core)
 
 # Build the bundled Stockfish engine. We cannot rely on ${CMAKE_MAKE_PROGRAM}
 # here, because the main project might use Ninja while the engine ships with a
-# traditional Makefile. Call make explicitly instead.
+# traditional Makefile. Instead try to locate a suitable `make` implementation
+# manually and use that to compile Stockfish.
+if(WIN32)
+    # On Windows the tool is typically called `mingw32-make` when using the
+    # MinGW toolchain that ships with Qt. Fall back to `make` if not found.
+    find_program(STOCKFISH_MAKE_EXE NAMES mingw32-make make)
+else()
+    # On Unix-like systems a plain `make` should be present.
+    find_program(STOCKFISH_MAKE_EXE NAMES make REQUIRED)
+endif()
+
 add_custom_target(build_stockfish ALL
-    COMMAND make build
+    COMMAND ${STOCKFISH_MAKE_EXE} build
 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/src
     COMMENT "Building Stockfish engine"


### PR DESCRIPTION
## Summary
- look for `mingw32-make` on Windows when building Stockfish
- fall back to regular `make` on other platforms

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68519fbd17b083208e2e42b688601a86