### PR TITLE
Fix Stockfish path detection for Vs AI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,16 @@ add_custom_target(build_stockfish ALL
     COMMENT "Building Stockfish engine"
 )
 
+if(WIN32)
+    set(STOCKFISH_EXE stockfish.exe)
+else()
+    set(STOCKFISH_EXE stockfish)
+endif()
+
 add_custom_command(TARGET build_stockfish POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/src/stockfish
-            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/stockfish
+            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/src/${STOCKFISH_EXE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/stockfish/engine/${STOCKFISH_EXE}
 )
 
 add_subdirectory(src)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,11 +94,16 @@ void MainWindow::startGame()
     if(m_mode==VsAi){
         if(!m_ai){
             m_ai = new QProcess(this);
-            QString prog = QCoreApplication::applicationDirPath()+"/../stockfish/engine/stockfish";
+#ifdef Q_OS_WIN
+            const QString exe = "stockfish.exe";
+#else
+            const QString exe = "stockfish";
+#endif
+            QString prog = QCoreApplication::applicationDirPath()+"/../stockfish/engine/" + exe;
             if(!QFile::exists(prog))
-                prog = QCoreApplication::applicationDirPath()+"/stockfish/engine/stockfish";
+                prog = QCoreApplication::applicationDirPath()+"/stockfish/engine/" + exe;
             if(!QFile::exists(prog))
-                prog = "stockfish";
+                prog = exe;
             m_ai->setProgram(prog);
             m_ai->start();
             if(m_ai->waitForStarted(1000)){


### PR DESCRIPTION
## Summary
- add platform check in MainWindow to use `stockfish.exe` on Windows

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6851a6f8afd88320a92f99ce53db4cc1