### PR TITLE
Improve Stockfish error handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -123,6 +123,10 @@ void MainWindow::startGame()
                 m_ai->write("isready\n");
                 m_ai->waitForReadyRead(1000);
                 m_ai->readAll();
+            }else{
+                QMessageBox::warning(this, "AI", "Failed to start Stockfish at " + prog);
+                delete m_ai;
+                m_ai = nullptr;
             }
         }
     }
@@ -196,8 +200,10 @@ void MainWindow::setHighlight(const QVector<QPoint> &moves)
 
 void MainWindow::requestAiMove()
 {
-    if(!m_ai || m_ai->state()!=QProcess::Running)
+    if(!m_ai || m_ai->state()!=QProcess::Running){
+        QMessageBox::warning(this, "AI", "Stockfish engine not running");
         return;
+    }
     QByteArray cmd = "position fen " + m_board.toFen().toUtf8() + "\n";
     cmd += "go depth 12\n";
     m_ai->write(cmd);


### PR DESCRIPTION
## Summary
- warn the user if Stockfish fails to start or isn't running

## Testing
- `make -C stockfish/engine/src clean`
- `./stockfish bench`

------
https://chatgpt.com/codex/tasks/task_e_6851b7bf3f848320bf3342d645dc6ccb