### PR TITLE
Improve AI engine start and move handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -93,39 +93,8 @@ void MainWindow::startGame()
     connect(m_view, &BoardView::boardChanged, this, &MainWindow::onBoardChange);
     connect(m_view, &BoardView::highlightChanged, this, &MainWindow::setHighlight);
 
-    if(m_mode==VsAi){
-        if(!m_ai){
-            m_ai = new QProcess(this);
-#ifdef Q_OS_WIN
-            const QString exe = "stockfish.exe";
-#else
-            const QString exe = "stockfish";
-#endif
-            QStringList searchPaths{
-                QCoreApplication::applicationDirPath()+"/../../stockfish/engine/" + exe,
-                QCoreApplication::applicationDirPath()+"/../stockfish/engine/" + exe,
-                QCoreApplication::applicationDirPath()+"/stockfish/engine/" + exe,
-                exe
-            };
-            QString prog;
-            for(const QString &p : searchPaths){
-                if(QFile::exists(p)){
-                    prog = p;
-                    break;
-                }
-            }
-            if(prog.isEmpty())
-                prog = exe;
-            m_ai->setProgram(prog);
-            m_ai->start();
-            if(m_ai->waitForStarted(1000)){
-                m_ai->write("uci\n");
-                m_ai->write("isready\n");
-                m_ai->waitForReadyRead(1000);
-                m_ai->readAll();
-            }
-        }
-    }
+    if(m_mode==VsAi)
+        startAiEngine();
 
 }
 
@@ -196,12 +165,13 @@ void MainWindow::setHighlight(const QVector<QPoint> &moves)
 
 void MainWindow::requestAiMove()
 {
+    startAiEngine();
     if(!m_ai || m_ai->state()!=QProcess::Running)
         return;
     QByteArray cmd = "position fen " + m_board.toFen().toUtf8() + "\n";
     cmd += "go depth 12\n";
     m_ai->write(cmd);
-    connect(m_ai, &QProcess::readyReadStandardOutput, this, &MainWindow::handleAiOutput);
+    connect(m_ai, &QProcess::readyReadStandardOutput, this, &MainWindow::handleAiOutput, Qt::UniqueConnection);
 }
 
 void MainWindow::handleAiOutput()
@@ -285,6 +255,55 @@ void MainWindow::updateTimerDisplay()
     auto format=[&](int t){ return QString("%1:%2").arg(t/60,2,10,QChar('0')).arg(t%60,2,10,QChar('0')); };
     m_whiteLabel->setText("White: " + format(m_whiteTime));
     m_blackLabel->setText("Black: " + format(m_blackTime));
+}
+
+void MainWindow::startAiEngine()
+{
+    if(m_ai && m_ai->state()==QProcess::Running)
+        return;
+
+    if(m_ai){
+        delete m_ai;
+        m_ai = nullptr;
+    }
+
+    m_ai = new QProcess(this);
+#ifdef Q_OS_WIN
+    const QString exe = "stockfish.exe";
+#else
+    const QString exe = "stockfish";
+#endif
+    QStringList searchPaths{
+        QCoreApplication::applicationDirPath()+"/../../stockfish/engine/" + exe,
+        QCoreApplication::applicationDirPath()+"/../stockfish/engine/" + exe,
+        QCoreApplication::applicationDirPath()+"/stockfish/engine/" + exe,
+        QCoreApplication::applicationDirPath()+"/../../stockfish/engine/src/" + exe,
+        QCoreApplication::applicationDirPath()+"/../stockfish/engine/src/" + exe,
+        QCoreApplication::applicationDirPath()+"/stockfish/engine/src/" + exe,
+        exe
+    };
+    QString prog;
+    for(const QString &p : searchPaths){
+        if(QFile::exists(p)){
+            prog = p;
+            break;
+        }
+    }
+    if(prog.isEmpty())
+        prog = exe;
+    m_ai->setProgram(prog);
+    m_ai->start();
+    m_aiBuffer.clear();
+    if(m_ai->waitForStarted(1000)){
+        m_ai->write("uci\n");
+        m_ai->write("isready\n");
+        m_ai->waitForReadyRead(1000);
+        m_ai->readAll();
+    }else{
+        QMessageBox::warning(this, "AI", "Failed to start Stockfish at " + prog);
+        delete m_ai;
+        m_ai = nullptr;
+    }
 }
 
 void MainWindow::resignGame()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -36,6 +36,7 @@ private:
     void showMenu();
     void endGame();
     void updateTimerDisplay();
+    void startAiEngine();
 
 private:
     enum Mode { Off, Offline, VsAi };


### PR DESCRIPTION
## Summary
- add fallback search paths for Stockfish binary in `startAiEngine`
- ensure single connection when reading AI output
- clear AI buffer when engine starts

## Testing
- `make -C stockfish/engine/src clean`
- `make -C stockfish/engine/src build`
- `./stockfish/engine/src/stockfish bench`

------
https://chatgpt.com/codex/tasks/task_e_6851b7bf3f848320bf3342d645dc6ccb